### PR TITLE
Fixing bad variable references

### DIFF
--- a/PostmanCollections3.x/EdFi_5_3.postman_collection.json
+++ b/PostmanCollections3.x/EdFi_5_3.postman_collection.json
@@ -9172,12 +9172,12 @@
 							"urlencoded": [
 								{
 									"key": "Client_id",
-									"value": "{{Key}}",
+									"value": "{{ClientId}}",
 									"type": "text"
 								},
 								{
 									"key": "Client_secret",
-									"value": "{{Secret}}",
+									"value": "{{ClientSecret}}",
 									"type": "text"
 								},
 								{
@@ -9188,9 +9188,9 @@
 							]
 						},
 						"url": {
-							"raw": "{{ApiRoot}}/oauth/token",
+							"raw": "{{oauthTokenUrl}}",
 							"host": [
-								"{{ApiRoot}}"
+								"{{ApiUrl}}"
 							],
 							"path": [
 								"oauth",

--- a/PostmanCollections3.x/EdFi_6_0.postman_collection.json
+++ b/PostmanCollections3.x/EdFi_6_0.postman_collection.json
@@ -8789,12 +8789,12 @@
 							"urlencoded": [
 								{
 									"key": "Client_id",
-									"value": "{{Key}}",
+									"value": "{{ClientId}}",
 									"type": "text"
 								},
 								{
 									"key": "Client_secret",
-									"value": "{{Secret}}",
+									"value": "{{ClientSecret}}",
 									"type": "text"
 								},
 								{
@@ -8805,9 +8805,9 @@
 							]
 						},
 						"url": {
-							"raw": "{{ApiRoot}}/oauth/token",
+							"raw": "{{oauthTokenUrl}}",
 							"host": [
-								"{{ApiRoot}}"
+								"{{ApiUrl}}"
 							],
 							"path": [
 								"oauth",


### PR DESCRIPTION
Found that there are a couple of variable references in both Postman collections that are pointing to variables that no longer exists, due to a change in name.